### PR TITLE
Fix `ironcore-in-a-box` git url

### DIFF
--- a/docs/iaas/getting-started.md
+++ b/docs/iaas/getting-started.md
@@ -20,7 +20,6 @@ The fastest way to get started with IronCore IaaS is to run it locally inside a 
 - make 
 - go
 - docker
-- kind
 
 ### Installation
 

--- a/docs/iaas/getting-started.md
+++ b/docs/iaas/getting-started.md
@@ -20,6 +20,7 @@ The fastest way to get started with IronCore IaaS is to run it locally inside a 
 - make 
 - go
 - docker
+- kind
 
 ### Installation
 

--- a/docs/iaas/getting-started.md
+++ b/docs/iaas/getting-started.md
@@ -26,7 +26,7 @@ The fastest way to get started with IronCore IaaS is to run it locally inside a 
 To do that clone the `ironcore-in-a-box` repository and run the provided script:
 
 ```bash
-git clone github.com/ironcore-dev/ironcore-in-a-box.git
+git clone https://github.com/ironcore-dev/ironcore-in-a-box.git
 ```
 
 To start the IronCore stack you simply run:


### PR DESCRIPTION
# Proposed Changes

- add `https://` to the `git clone` url
- add `kind` as prerequesite

@afritzler 