### PR TITLE
Add usage doc for `VolumeSnapshot`

### DIFF
--- a/docs/iaas/kubernetes/cloud-controller-manager.md
+++ b/docs/iaas/kubernetes/cloud-controller-manager.md
@@ -47,10 +47,10 @@ explanation on how APIs are implemented in IronCore cloud-provider.
 ### Ensure LoadBalancer
 
 - `EnsureLoadBalancer` gets the LoadBalancer name based on service name.
-- Checks if IronCore `LoadBalancer` object already exists. If not it gets the `port` and `protocol`, `ipFamily` information from the service and creates a new LoadBalancer object in the Ironcore. 
+- Checks if IronCore `LoadBalancer` object already exists. If not it gets the `port` and `protocol`, `ipFamily` information from the service and creates a new LoadBalancer object in the IronCore. 
 - Newly created LoadBalancer will be associated with Network reference provided in cloud configuration.
-- Then `LoadBalancerRouting` object is created with the destination IP information retrieved from the nodes (Note: `LoadBalancerRouting` is internal object to Ironcore). Later, this information is used at the Ironcore API level to describe the explicit targets in a pool traffic is routed to.
-- Ironcore supports two types of LoadBalancer `Public` and `Internal`. If LoadBalancer has to be of type Internal, "service.beta.kubernetes.io/ironcore-load-balancer-internal" annotation needs to be set to true, otherwise it will be considered as public type.
+- Then `LoadBalancerRouting` object is created with the destination IP information retrieved from the nodes (Note: `LoadBalancerRouting` is internal object to IronCore). Later, this information is used at the IronCore API level to describe the explicit targets in a pool traffic is routed to.
+- IronCore supports two types of LoadBalancer `Public` and `Internal`. If LoadBalancer has to be of type Internal, "service.beta.kubernetes.io/ironcore-load-balancer-internal" annotation needs to be set to true, otherwise it will be considered as public type.
 
 ### Update LoadBalancer
 

--- a/docs/iaas/usage-guides/networking.md
+++ b/docs/iaas/usage-guides/networking.md
@@ -39,7 +39,7 @@ The format of a network providerID is as follows:
     - The `binding` phase of a `spec.peerings` item is reflected in a corresponding `status.peerings` item with the same name. The phase can either be `Pending`, meaning there is no active peering or `Bound` meaning the peering as described in the `spec.peerings` item is in place.
 
 
-After successful reconciliation, the Ironcore `Network` resource gets updated with `providerID`, `incomingpeerings` and `status`.
+After successful reconciliation, the IronCore `Network` resource gets updated with `providerID`, `incomingpeerings` and `status`.
 
 ```yaml
 apiVersion: networking.ironcore.dev/v1alpha1

--- a/docs/iaas/usage-guides/storage.md
+++ b/docs/iaas/usage-guides/storage.md
@@ -1,5 +1,12 @@
 # Storage Resources
-IronCore storage resources are `Volumes`, their associated `Volumeclasses` and `VolumePools` that allow you to define, provision, and manage Block devices in the Ironcore infrastructure. This guide explains the core storage resource types and how to use them.
+IronCore storage resources are
+- `Volumes`, their associated `Volumeclasses` and `VolumePools` that allow you to define, provision, and manage Block devices in the IronCore infrastructure.
+
+- `Buckets`, their associated `Bucketclasses` and `BucketPools`, that allow you to define, provision, and manage the object storage such as files or data blobs.
+
+- `VolumeSnapshots`, that allow users to take a point-in-time snapshot of an IronCore `Volume` content. It can be used to restore the data in case of data loss or to migrate the data to a different cluster or storage system. Also an Ironcore `Volume` can be provisioned by referencing a `VolumeSnapshot`.
+
+This guide explains the core storage resource types and how to use them.
 
 ## Volume
 
@@ -59,7 +66,7 @@ capabilities:
 
 ## VolumePool
 
-A `VolumePool` is a resource in `Ironcore` that represents a pool of storage volume managed collectively. It defines 
+A `VolumePool` is a resource in IronCore that represents a pool of storage volume managed collectively. It defines 
 the infrastructure's storage configuration used to provision and manage volumes, ensuring resource availability and 
 compatibility with associated `VolumeClasses`.
 
@@ -119,7 +126,7 @@ spec:
 
 A `BucketClass` is a concept used to define and manage different types of storage buckets, typically based on resource 
 capabilities. It is conceptually similar to Kubernetes `StorageClass`, enabling users to specify the desired properties 
-for an Ironcore `Bucket` resource creation.
+for an IronCore `Bucket` resource creation.
 
 ### Example BucketClass Resource
 
@@ -149,7 +156,7 @@ capabilities:
 
 ## BucketPool
 
-A `BucketPool` is a resource in `Ironcore` that represents a pool of storage buckets managed collectively. It defines
+A `BucketPool` is a resource in IronCore that represents a pool of storage buckets managed collectively. It defines
 the infrastructure's storage configuration used to provision and manage buckets, ensuring resource availability and 
 compatibility with associated `BucketClasses`.
 
@@ -169,3 +176,25 @@ spec:
 ### Key Fields:
 
 - `ProviderID` (`string`): The `providerId` helps the controller identify and communicate with the correct storage system within the specific backened storage provider.
+
+## VolumeSnapshot
+
+The IronCore `VolumeSnapshot` resource allows users to take point-in-time snapshots of the content of a `Volume` without creating an entirely new volume. This functionality allows users to take backup before performing any modifications on data.
+
+### Example VolumeSnapshot Resource
+
+An example of how to define a `VolumeSnapshot` resource in IronCore:
+
+```yaml
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: VolumeSnapshot
+metadata:
+  name: volumesnapshot-sample
+spec:
+  volumeRef:
+    name: volume-sample
+```
+
+### Key Fields:
+
+- `volumeRef` (`string`): `volumeRef` refers to the name of an IronCore `volume` to create a volumeSnapshot.

--- a/docs/iaas/usage-guides/storage.md
+++ b/docs/iaas/usage-guides/storage.md
@@ -4,7 +4,7 @@ IronCore storage resources are
 
 - `Buckets`, their associated `Bucketclasses` and `BucketPools`, that allow you to define, provision, and manage the object storage such as files or data blobs.
 
-- `VolumeSnapshots`, that allow users to take a point-in-time snapshot of an IronCore `Volume` content. It can be used to restore the data in case of data loss or to migrate the data to a different cluster or storage system. Also an Ironcore `Volume` can be provisioned by referencing a `VolumeSnapshot`.
+- `VolumeSnapshots`, that allow users to take a point-in-time snapshot of an IronCore `Volume` content. It can be used to restore the data in case of data loss or to migrate the data to a different cluster or storage system. Also an IronCore `Volume` can be provisioned by referencing a `VolumeSnapshot`.
 
 This guide explains the core storage resource types and how to use them.
 


### PR DESCRIPTION
- Update `usage-guides/storage.md` for`VolumeSnapshot` resource


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Kubernetes cloud controller manager docs (reflowed EnsureLoadBalancer section for readability).
  * Fixed capitalization in networking guide ("IronCore").
  * Added VolumeSnapshot resource docs with example and key fields; expanded storage overview to include Buckets and VolumeSnapshots and refined related descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->