### PR TITLE
Update sonic-operator link

### DIFF
--- a/docs/network-automation/index.md
+++ b/docs/network-automation/index.md
@@ -13,4 +13,4 @@ a Kubernetes-based architecture to streamline the deployment, configuration, and
 The IronCore project supports different vendors and device types through dedicated operators. Below are some of the key components:
 
 - [network-operator](https://ironcore.dev/network-operator/): Automation for Cisco NX-OS devices.
-- [sonic-operator](https://github.com/ironcore-dev/sonic-operator/): Automation for Sonic Edgecore switches.
+- [sonic-operator](https://ironcore.dev/sonic-operator/): Automation for Sonic Edgecore switches.


### PR DESCRIPTION

## Summary by CodeRabbit

* **Documentation**
  * Updated sonic-operator reference link to use the official IronCore domain for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->