### PR TITLE
Add community meetings page

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -18,6 +18,11 @@ All IronCore development happens in the open on [GitHub](https://github.com/iron
 - Report bugs or request features by opening an [issue](https://github.com/ironcore-dev/ironcore/issues)
 - Follow the project's development and roadmap
 
+### Community Meetings
+
+The IronCore community holds regular meetings to discuss ongoing development, feature proposals, and other community topics.
+Visit our [Meetings Overview](/community/meetings) if you're interested in attending.
+
 ## Contribute
 
 We welcome contributions of all kinds — from code and documentation to bug reports and feature ideas. If you'd like to

--- a/docs/community/meetings.md
+++ b/docs/community/meetings.md
@@ -1,0 +1,19 @@
+# Community Meetings
+
+The IronCore community holds regular meetings to discuss ongoing development, feature proposals, and other community topics.
+These meetings are open to everyone interested in IronCore, whether you're a developer, user, or just curious about the project.
+
+If you'd like to bring your own topic, feel free to add it to the [agenda](#meeting-agenda).
+
+## Meeting Schedule
+
+Visit the [community calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/ironcore?view=week) for upcoming meetings.
+
+## Meeting Agenda
+
+The agenda for the next meetings is maintained in our [Slack workspace](https://join.slack.com/t/ironcore-dev/shared_invite/zt-3o0qo3j90-pbqV0io1B~Z~LqeAp4n2Vg).
+Join the workspace to be able to see the agenda and add your own topics.
+
+These are the existing meeting series and their agendas:
+
+- [IronCore IaaS Community Call / Office Hour](https://ironcore-dev.slack.com/docs/T01V4AK8HQ8/F0AM7CXFKQV)


### PR DESCRIPTION
# Proposed Changes

- Add a new page covering community meetings and links to the agendas in Slack
- Link the community meetings page to the community index


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a Community Meetings section to the community index page, introducing that the IronCore community holds regular meetings to discuss development and feature proposals, with a link to the Meetings Overview page.
* Created a new Meetings Overview documentation page providing meeting purpose, details on accessing the community calendar for schedules, the Slack workspace for managing agenda items, and meeting access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->