### PR TITLE
baremetal: Fix "Next page" navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -142,7 +142,7 @@ export default withMermaid({
         text: "Architecture",
         collapsed: false,
         items: [
-          { text: 'Overview', link: '/baremetal/architecture' },
+          { text: 'Overview', link: '/baremetal/architecture/' },
           { text: 'Discovery', link: '/baremetal/architecture/discovery' },
           { text: 'Provisioning', link: '/baremetal/architecture/provisioning' },
         ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -133,7 +133,10 @@ export default withMermaid({
       ],
     '/baremetal/': [
       {
-        text: 'Overview', link: '/baremetal/',
+        text: 'Bare Metal Management',
+        items: [
+          { text: 'Overview', link: '/baremetal/' },
+        ],
       },
       {
         text: "Architecture",


### PR DESCRIPTION
"Next page" buttons on '/baremetal' and '/baremetal/architecture' pages went in circle. This change fixes it, so that you can continue from '/baremetal/architecture' to '/baremental/architecture/discovery' with the "Next page" button.

Additionally, a section "title" was added to the "Bare Metal Management", to make it more clear which section of the IronCore documentation you are in.

# Proposed Changes

- Add "Bare Metal Management" navigation title
- Fix circular "Next page" navigation in Bare Metal section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Bare Metal Management documentation sidebar with an improved top-level navigation group for better accessibility
  * Added a new Overview link within the Bare Metal Management section to help users quickly find core documentation
  * Updated documentation link paths to ensure consistency and reliability across all Bare Metal Management references and related resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/ironcore-dev.github.io/pull/126)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->